### PR TITLE
解决通过点击通知冷启app后，调用onNotificationOpened无效的问题

### DIFF
--- a/android/src/main/kotlin/com/aliyun/ams/push/AliyunPushMessageReceiver.kt
+++ b/android/src/main/kotlin/com/aliyun/ams/push/AliyunPushMessageReceiver.kt
@@ -50,7 +50,7 @@ class AliyunPushMessageReceiver : MessageReceiver() {
             "extraMap" to extraMap
         )
         
-        AliyunPushPlugin.sInstance.callFlutterMethod("onNotification", arguments)
+        AliyunPushPlugin.sInstance?.callFlutterMethod("onNotification", arguments)
     }
 
     // 应用处于前台时通知到达回调
@@ -72,7 +72,7 @@ class AliyunPushMessageReceiver : MessageReceiver() {
             "openUrl" to openUrl
         )
 
-        AliyunPushPlugin.sInstance.callFlutterMethod("onNotificationReceivedInApp", arguments)
+        AliyunPushPlugin.sInstance?.callFlutterMethod("onNotificationReceivedInApp", arguments)
     }
 
     // 推送消息的回调方法
@@ -85,7 +85,7 @@ class AliyunPushMessageReceiver : MessageReceiver() {
             "traceInfo" to cPushMessage.traceInfo
         )
 
-        AliyunPushPlugin.sInstance.callFlutterMethod("onMessage", arguments)
+        AliyunPushPlugin.sInstance?.callFlutterMethod("onMessage", arguments)
     }
 
     // 从通知栏打开通知的扩展处理
@@ -101,7 +101,7 @@ class AliyunPushMessageReceiver : MessageReceiver() {
             "extraMap" to extraMap
         )
 
-        AliyunPushPlugin.sInstance.callFlutterMethod("onNotificationOpened", arguments)
+        AliyunPushPlugin.sInstance?.callFlutterMethod("onNotificationOpened", arguments)
     }
 
     // 通知删除回调
@@ -110,7 +110,7 @@ class AliyunPushMessageReceiver : MessageReceiver() {
             "msgId" to messageId
         )
 
-        AliyunPushPlugin.sInstance.callFlutterMethod("onNotificationRemoved", arguments)
+        AliyunPushPlugin.sInstance?.callFlutterMethod("onNotificationRemoved", arguments)
     }
 
     // 无动作通知点击回调（当在后台或阿里云控制台指定的通知动作为无逻辑跳转时）
@@ -126,6 +126,6 @@ class AliyunPushMessageReceiver : MessageReceiver() {
             "extraMap" to extraMap
         )
 
-        AliyunPushPlugin.sInstance.callFlutterMethod("onNotificationClickedWithNoAction", arguments)
+        AliyunPushPlugin.sInstance?.callFlutterMethod("onNotificationClickedWithNoAction", arguments)
     }
 }

--- a/android/src/main/kotlin/com/aliyun/ams/push/AliyunPushPlugin.kt
+++ b/android/src/main/kotlin/com/aliyun/ams/push/AliyunPushPlugin.kt
@@ -43,7 +43,7 @@ class AliyunPushPlugin : FlutterPlugin, MethodCallHandler {
         private const val ERROR_MSG_KEY = "errorMsg"
 
         @SuppressLint("StaticFieldLeak")
-        lateinit var sInstance: AliyunPushPlugin
+        var sInstance: AliyunPushPlugin? = null
     }
 
     /// The MethodChannel that will the communication between Flutter and native Android

--- a/android/src/main/kotlin/com/aliyun/ams/push/PushPopupActivity.kt
+++ b/android/src/main/kotlin/com/aliyun/ams/push/PushPopupActivity.kt
@@ -3,6 +3,8 @@ package com.aliyun.ams.push
 import android.content.Intent
 import android.os.Bundle
 import com.alibaba.sdk.android.push.AndroidPopupActivity
+import java.util.Timer
+import java.util.TimerTask
 
 class PushPopupActivity : AndroidPopupActivity() {
     companion object {
@@ -10,6 +12,7 @@ class PushPopupActivity : AndroidPopupActivity() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        AliyunPushLog.d(TAG, "辅助弹窗已创建")
         super.onCreate(savedInstanceState)
     }
 
@@ -22,7 +25,6 @@ class PushPopupActivity : AndroidPopupActivity() {
                 setClassName(this@PushPopupActivity, "$packageName.MainActivity")
                 addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
             }
-
             startActivity(intent)
 
             val arguments = mapOf(
@@ -31,8 +33,21 @@ class PushPopupActivity : AndroidPopupActivity() {
                 "extraMap" to extMap
             )
 
-            AliyunPushPlugin.sInstance.callFlutterMethod("onNotificationOpened", arguments)
-        } catch (e: Exception){
+            val t = Timer()
+            val task = object : TimerTask() {
+                override fun run() {
+                    if (AliyunPushPlugin.sInstance != null) {
+                        t.cancel()
+                        AliyunPushPlugin.sInstance?.callFlutterMethod(
+                            "onNotificationOpened",
+                            arguments
+                        )
+                        AliyunPushLog.d(TAG, "辅助弹窗通知参数: $arguments")
+                    }
+                }
+            }
+            t.schedule(task, 1000, 200)
+        } catch (e: Exception) {
             AliyunPushLog.e(TAG, "打开通知出错: $e")
         }
 


### PR DESCRIPTION
点击通知冷启app,android/ios插件尚未来得及初始化，或者app回调注册尚未完成，导致 `onNotificationOpened`调用无效，app无法对extra参数进行处理，实现不了根据参数跳转到指定页面等业务逻辑。