### PR TITLE
fix: get launchIntent via packageName.

### DIFF
--- a/android/src/main/kotlin/com/aliyun/ams/push/PushPopupActivity.kt
+++ b/android/src/main/kotlin/com/aliyun/ams/push/PushPopupActivity.kt
@@ -17,13 +17,11 @@ class PushPopupActivity : AndroidPopupActivity() {
     override fun onSysNoticeOpened(title: String, summary: String, extMap: Map<String, String>) {
         try {
             // 启动MainActivity
-            val intent = Intent().apply {
-                val packageName = packageName
-                setClassName(this@PushPopupActivity, "$packageName.MainActivity")
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            val launchIntent = packageManager.getLaunchIntentForPackage(packageName)
+            if (launchIntent != null) {
+                launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                startActivity(launchIntent)
             }
-
-            startActivity(intent)
 
             val arguments = mapOf(
                 "title" to title,


### PR DESCRIPTION
建议使用这种方式来获取activity。
生产过程中会遇到多包名的情况，项目中配置了类似这种，包名就不一样了，会找不到activity。
```
productFlavors {
        dev {
            dimension "env"
            applicationId "com.example.app.dev"
        }
        universal {
            dimension "env"
            applicationId "com.example.app.dev.universal"
        }
        prod {
            dimension "env"
            applicationId "com.example.app.prod"
        }
    }
```