### PR TITLE
1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.3
+- 修复阿里云官方移除 iOS SDK 3.1.1 导致不能安装问题，改为不依赖指定版本
+- Android SDK 升级至 3.9.5
+
 ## 1.3.2
 - 修复点击推送通知冷启动App时onNotificationOpened无效的问题
 - Android SDK 升级至 3.9.4.1

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -59,7 +59,7 @@ android {
     }
 
     dependencies {
-        api "com.aliyun.ams:alicloud-android-push:3.9.4.1"
+        api "com.aliyun.ams:alicloud-android-push:3.9.5"
 
         api "com.aliyun.ams:alicloud-android-third-push:3.9.4.1"
         api "com.aliyun.ams:alicloud-android-third-push-meizu:3.9.4.1"

--- a/ios/aliyun_push_flutter.podspec
+++ b/ios/aliyun_push_flutter.podspec
@@ -15,7 +15,7 @@ A new Flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'AlicloudPush', '~> 3.1.1'
+  s.dependency 'AlicloudPush'
   s.platform = :ios, '12.0'
   s.static_framework = true
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: aliyun_push_flutter
 description: "Aliyun Push Flutter plugin, providing support for both Android and iOS platforms to enable push notification functionality in your Flutter applications."
-version: 1.3.2
+version: 1.3.3
 homepage: "https://help.aliyun.com/document_detail/2584336.html"
 repository: "https://github.com/OpenMindOpenWorld/aliyun-push-flutter-plugin"
 


### PR DESCRIPTION
- 修复阿里云官方移除 iOS SDK 3.1.1 导致不能安装问题，改为不依赖指定版本
- Android SDK 升级至 3.9.5